### PR TITLE
EstimatorFailure

### DIFF
--- a/skdim/errors.py
+++ b/skdim/errors.py
@@ -1,0 +1,3 @@
+class EstimatorFailure(Exception):
+    """An Exception class to be used when an estimator cannot return an output."""
+    pass

--- a/skdim/id_flex/_MLE_basic.py
+++ b/skdim/id_flex/_MLE_basic.py
@@ -3,6 +3,7 @@ import numpy as np
 import scipy
 from .._commonfuncs import FlexNbhdEstimator
 from sklearn.metrics import DistanceMetric
+from ..errors import EstimatorFailure
 
 class MLE_basic(FlexNbhdEstimator):
     '''
@@ -35,7 +36,7 @@ class MLE_basic(FlexNbhdEstimator):
             minv = N*np.log(radius)-np.sum(np.log(dlist))
 
             if minv < 1e-9:
-                raise Exception("MLE estimation diverges.")
+                raise EstimatorFailure("MLE estimation diverges.")
             else:
                 if nbhd_type == 'eps':
                     return np.divide(N, minv)

--- a/skdim/tests/flex/mle_basic_test.py
+++ b/skdim/tests/flex/mle_basic_test.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 import skdim.id_flex
 from sklearn.datasets import make_swiss_roll
+from ...errors import EstimatorFailure
 
 def __generate_distance_matrix(size, threshold=10, maximum=100):
     # Generate a random distance matrix with values between 0 and 1sklea
@@ -33,7 +34,7 @@ def test_on_equal_distances():
     for i in range(SIZE):
         distances[i,i] = 0.0
     mle = skdim.id_flex.MLE_basic()
-    with pytest.raises(Exception):
+    with pytest.raises(EstimatorFailure):
         mle.fit_pw(distances, metric="precomputed", n_neighbors=3)
 
 def test_on_exponential_seq_of_distances():


### PR DESCRIPTION
I suggest that we use a custom exception `EstimatorFailure` for cases where an estimator cannot return a value