### PR TITLE
Flex nbhd fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+skdimvenv/
 *.vscode
 *.idea
 *.ini
@@ -72,3 +73,4 @@ target/
 /bin
 pyvenv.cfg
 /share
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy<=1.20
+numpy
 scipy
 scikit-learn
 numba

--- a/skdim/_commonfuncs.py
+++ b/skdim/_commonfuncs.py
@@ -391,7 +391,7 @@ class FlexNbhdEstimator(BaseEstimator):
         kwargs: keyword arguments, such as 'n_neighbors', or 'radius' for sklearn NearestNeighbor to infer local neighbourhoods
         """
 
-        self._pw_dim = pw_dim #a protected method 
+        self.pw_dim = pw_dim 
         self.nbhd_type = nbhd_type
         self.pt_nbhd_incl_pt = pt_nbhd_incl_pt 
         self.metric = metric
@@ -406,11 +406,11 @@ class FlexNbhdEstimator(BaseEstimator):
         
     def attr_checks(self):
 
-        if not isinstance(self._pw_dim, bool):
+        if not isinstance(self.pw_dim, bool):
             raise TypeError(
                     "Invalid pw_dim parameter. It has to be bool"
                 )
-        elif self._pw_dim: #global estimator
+        elif self.pw_dim: #global estimator
             if self.comb is not None:
                 raise ValueError(
                     "Estimator does not produce pointwise dimension estimate, no aggregation over pointwise dimension estimates is implemented."
@@ -497,7 +497,7 @@ class FlexNbhdEstimator(BaseEstimator):
             nbhd_indices=nbhd_indices,
         )
 
-        if self._pw_dim: self.aggr()
+        if self.pw_dim: self.aggr()
 
         return self
 
@@ -532,7 +532,7 @@ class FlexNbhdEstimator(BaseEstimator):
             radial_dists=radial_dists
         )
 
-        if self._pw_dim:
+        if self.pw_dim:
             self.is_fitted_pw_ = True
 
             if self.smooth_flag:

--- a/skdim/_commonfuncs.py
+++ b/skdim/_commonfuncs.py
@@ -398,7 +398,6 @@ class FlexNbhdEstimator(BaseEstimator):
         self.radius = radius
         self.n_neighbors = n_neighbors
 
-        self.attr_checks()
 
         
         
@@ -530,6 +529,8 @@ class FlexNbhdEstimator(BaseEstimator):
         radial_dist: ndarray of shape (n_samples,) of arrays recording distance from point to neighbours
 
         """
+        self.attr_checks()
+        
         neigh = NearestNeighbors(
             metric=self.metric, n_jobs= self.n_jobs, n_neighbors=self.n_neighbors, radius=self.radius
         )

--- a/skdim/_commonfuncs.py
+++ b/skdim/_commonfuncs.py
@@ -463,7 +463,7 @@ class FlexNbhdEstimator(BaseEstimator):
         X: (n_samples, n_features) or (n_samples, n_samples) if metric=’precomputed’
         
         """
-        if self.nbhd_type is not 'custom':
+        if self.nbhd_type != 'custom':
             nbhd_indices, radial_dists = self.get_neigh(X)
             # N.B. if use native sklearn NearestNeighbors, nbhd_indices is either
             # in the knn case (N_pts x extrinsic_dim) np array,

--- a/skdim/id_flex/_MLE_basic.py
+++ b/skdim/id_flex/_MLE_basic.py
@@ -1,10 +1,7 @@
-import inspect
 import numpy as np
-import scipy
 from .._commonfuncs import FlexNbhdEstimator
-from sklearn.metrics import DistanceMetric
 from ..errors import EstimatorFailure
-import warnings 
+
 
 class MLE_basic(FlexNbhdEstimator):
     '''
@@ -23,10 +20,6 @@ class MLE_basic(FlexNbhdEstimator):
             raise ValueError(
                     "Invalid nbhd_type parameter. It has to be 'knn' or 'eps' for Levina-Bickel."
                 )
-        
-        if self.pt_nbhd_incl_pt:
-            warnings.warn('The method by Levina Bickel by does not include a point itself in the neighbourhood. The parameter pt_nbhd_incl_pt is forced to be False.') 
-            self.pt_nbhd_incl_pt = False
         
         #self.average_steps = average_steps #to do: integrate averaging over k neighbourhoods
 

--- a/skdim/id_flex/_MLE_basic.py
+++ b/skdim/id_flex/_MLE_basic.py
@@ -14,7 +14,7 @@ class MLE_basic(FlexNbhdEstimator):
         
 
     def __init__(self, nbhd_type = 'knn', metric = 'euclidean', comb = 'mean', smooth = False, n_jobs = 1, radius = 1.0, n_neighbors = 5):
-        super().__init__(nbhd_type = nbhd_type, pt_nbhd_incl_pt = False, metric = metric, comb = comb, smooth = smooth, n_jobs = n_jobs, radius = radius, n_neighbors = n_neighbors)
+        super().__init__(pw_dim = True, nbhd_type = nbhd_type, pt_nbhd_incl_pt = False, metric = metric, comb = comb, smooth = smooth, n_jobs = n_jobs, radius = radius, n_neighbors = n_neighbors, sort_radial = False)
         
         if self.nbhd_type not in ['knn', 'eps']:
             raise ValueError(

--- a/skdim/tests/flex/mle_basic_test.py
+++ b/skdim/tests/flex/mle_basic_test.py
@@ -22,16 +22,16 @@ def __generate_distance_matrix(size, threshold=10, maximum=100):
 def test_on_swiss_roll():
     np.random.seed(782)
     swiss_roll_dat = make_swiss_roll(1000)
-    mle = skdim.id_flex.MLE_basic(11)
-    estim_dim = mle.fit_transform(swiss_roll_dat[0], nbhd_type = 'knn', n_neighbors=20)
+    mle = skdim.id_flex.MLE_basic(nbhd_type = 'knn', n_neighbors=20)
+    estim_dim = mle.fit_transform(swiss_roll_dat[0])
     # The expected value is taken from Levina and Bickel's paper
     assert 2.1 == pytest.approx(estim_dim, 0.1)
 
 def test_on_swiss_roll_hmean():
     np.random.seed(782)
     swiss_roll_dat = make_swiss_roll(1000)
-    mle = skdim.id_flex.MLE_basic(11)
-    estim_dim = mle.fit_transform(swiss_roll_dat[0], nbhd_type = 'knn', n_neighbors=20, comb='hmean')
+    mle = skdim.id_flex.MLE_basic(nbhd_type = 'knn', n_neighbors=20, comb='hmean')
+    estim_dim = mle.fit_transform(swiss_roll_dat[0])
     # No standard expected result
     assert 2.0 == pytest.approx(estim_dim, 0.1)
 
@@ -41,9 +41,9 @@ def test_on_equal_distances():
     distances = np.full((SIZE, SIZE), 0.75)
     for i in range(SIZE):
         distances[i,i] = 0.0
-    mle = skdim.id_flex.MLE_basic()
+    mle = skdim.id_flex.MLE_basic( metric="precomputed", n_neighbors=3)
     with pytest.raises(skdim.errors.EstimatorFailure):
-        mle.fit_pw(distances, metric="precomputed", n_neighbors=3)
+        mle.fit_pw(distances)
 
 def test_on_exponential_seq_of_distances():
     np.random.seed(356)
@@ -52,35 +52,47 @@ def test_on_exponential_seq_of_distances():
     for i in range(1, SIZE):
         dist_matrix[0, i] = np.exp(i)
         dist_matrix[i, 0] = np.exp(i)
-    mle = skdim.id_flex.MLE_basic()
-    estim_dim = mle.fit_transform_pw(dist_matrix, metric="precomputed", nbhd_type = 'knn', n_neighbors=2)[0]
+
+    mle = skdim.id_flex.MLE_basic(metric="precomputed", nbhd_type = 'knn', n_neighbors=2)
+    estim_dim = mle.fit_transform_pw(dist_matrix)[0]
     assert 1.0 == pytest.approx(estim_dim)
-    estim_dim = mle.fit_transform_pw(dist_matrix,  metric="precomputed", nbhd_type = 'knn', n_neighbors=3)[0]
+
+    mle = skdim.id_flex.MLE_basic(metric="precomputed", nbhd_type = 'knn', n_neighbors=3)
+    estim_dim = mle.fit_transform_pw(dist_matrix)[0]
     assert 2.0 / 3.0 == pytest.approx(estim_dim)
-    estim_dim = mle.fit_transform_pw(dist_matrix, metric="precomputed", nbhd_type = 'knn', n_neighbors=4)[0]
+
+    mle = skdim.id_flex.MLE_basic(metric="precomputed", nbhd_type = 'knn', n_neighbors=4)
+    estim_dim = mle.fit_transform_pw(dist_matrix)[0]
     assert 0.5  == pytest.approx(estim_dim)
 
 def test_exception_is_raised_when_neighbourhoods_empty():
     np.random.seed(123)
     dist_matrix = __generate_distance_matrix(10, 12)
-    mle = skdim.id_flex.MLE_basic()
+    mle = skdim.id_flex.MLE_basic(nbhd_type = 'eps', metric = 'precomputed', radius = 5)
     with pytest.raises(ValueError): 
-        mle.fit_transform(dist_matrix, nbhd_type = 'eps', metric = 'precomputed', radius = 5)
+        mle.fit_transform(dist_matrix)
 
 def test_when_eps_and_knn_almost_equivalent():
-    mle = skdim.id_flex.MLE_basic()
+    
     rectangle = np.zeros((4,4))
     rectangle[1:3, 1] = 2
     rectangle[:2, 0] = 1
-    knn_estim = mle.fit_transform(rectangle, nbhd_type = 'knn', n_neighbors=2)
-    eps_estim = mle.fit_transform(rectangle, nbhd_type = 'eps', radius=2)
+
+    knn_mle = skdim.id_flex.MLE_basic(nbhd_type = 'knn', n_neighbors=2)
+    eps_mle = skdim.id_flex.MLE_basic(nbhd_type = 'eps', radius = 2)
+
+    knn_estim = knn_mle.fit_transform(rectangle)
+    eps_estim = eps_mle.fit_transform(rectangle)
+
     assert knn_estim * 2.0 == pytest.approx(eps_estim)
 
 def test_estim_decrease_when_eps_bigger_then_set_diameter():
     np.random.seed(567)
     eps_list = [10, 20, 30, 40, 50, 60]
-    mle = skdim.id_flex.MLE_basic()
     dist_matrix = __generate_distance_matrix(10, 0, 10)
-    results = [mle.fit_transform(dist_matrix, nbhd_type = 'eps', metric="precomputed", radius=eps) for eps in eps_list]
+    results = []
+    for eps in eps_list:
+        mle = skdim.id_flex.MLE_basic( nbhd_type = 'eps', metric="precomputed", radius=eps)
+        results.append(mle.fit_transform(dist_matrix))
     for i in range(1, len(results)):
         assert results[i] < results[i-1]

--- a/skdim/tests/flex/mle_basic_test.py
+++ b/skdim/tests/flex/mle_basic_test.py
@@ -43,7 +43,7 @@ def test_on_equal_distances():
         distances[i,i] = 0.0
     mle = skdim.id_flex.MLE_basic( metric="precomputed", n_neighbors=3)
     with pytest.raises(skdim.errors.EstimatorFailure):
-        mle.fit_pw(distances)
+        mle._fit_pw(distances)
 
 def test_on_exponential_seq_of_distances():
     np.random.seed(356)

--- a/skdim/tests/flex/test_FlexNbhdEstimator.py
+++ b/skdim/tests/flex/test_FlexNbhdEstimator.py
@@ -20,9 +20,9 @@ def test_fit_unknown_neighborhood(estim_class, data):
 
 @pytest.mark.parametrize("estim_class", estimators)
 def test_fit_unknown_metric(estim_class, data):
-    estimator = estim_class(metric="wrong_unknown_metric")
     with pytest.raises(ValueError):
-        estimator.fit_transform(data)
+        estimator = estim_class(metric="wrong_unknown_metric")
+        #estimator.fit_transform(data)
 
 @pytest.mark.parametrize("estim_class", estimators)
 def test_aggregation_unknown_comb(estim_class, data):
@@ -39,9 +39,9 @@ def test_get_neigh_unknown_neighborhood(estim_class, data):
 
 @pytest.mark.parametrize("estim_class", estimators)
 def test_get_neigh_unknown_metric(estim_class, data):
-    estimator = estim_class(metric="wrong_unknown_metric")
     with pytest.raises(ValueError):
-        estimator.get_neigh(data)
+        estimator = estim_class(metric="wrong_unknown_metric")
+        #estimator.get_neigh(data)
 
 @pytest.mark.parametrize("estim_class", estimators)
 def test_aggregation_computes_global_dim(estim_class, data):

--- a/skdim/tests/flex/test_FlexNbhdEstimator.py
+++ b/skdim/tests/flex/test_FlexNbhdEstimator.py
@@ -46,8 +46,8 @@ def test_get_neigh_unknown_metric(estim_class, data):
 @pytest.mark.parametrize("estim_class", estimators)
 def test_aggregation_computes_global_dim(estim_class, data):
     estimator = estim_class()
-    estimator.fit_pw(data)
-    estimator.aggr()
+    estimator._fit_pw(data)
+    estimator._aggr()
     assert hasattr(estimator, "dimension_")
 
 @pytest.mark.parametrize("estim_class", estimators)
@@ -59,7 +59,7 @@ def test_fit_computes_global_dim(estim_class, data):
 @pytest.mark.parametrize("estim_class", estimators)
 def test_fit_pw_computes_pw_dim(estim_class, data):
     estimator = estim_class()
-    estimator.fit_pw(data)
+    estimator._fit_pw(data)
     assert hasattr(estimator, "dimension_pw_")
 
 @pytest.mark.parametrize("estim_class", estimators)
@@ -73,14 +73,14 @@ def test_fit_single_job_equal_to_fit(estim_class, data):
 @pytest.mark.parametrize("estim_class", estimators)
 def test_fit_pw_single_job_equal_to_fit_pw(estim_class, data):
     estimator_single = estim_class()
-    estimator_single.fit_pw(data)
+    estimator_single._fit_pw(data)
     estimator_multi = estim_class(n_jobs=4)
-    estimator_multi.fit_pw(data)
+    estimator_multi._fit_pw(data)
     assert np.allclose(estimator_multi.dimension_pw_, estimator_single.dimension_pw_)
 
 @pytest.mark.parametrize("estim_class", estimators)
 def test_fit_transform_pw_is_fit_pw_plus_transform_pw(estim_class, data):
     estimator = estim_class()
-    estimator.fit_pw(data)
+    estimator._fit_pw(data)
     second_estimator = estim_class()
     assert np.allclose(second_estimator.fit_transform_pw(data), estimator.transform_pw(data))

--- a/skdim/tests/flex/test_FlexNbhdEstimator.py
+++ b/skdim/tests/flex/test_FlexNbhdEstimator.py
@@ -14,33 +14,34 @@ def data():
 
 @pytest.mark.parametrize("estim_class", estimators)
 def test_fit_unknown_neighborhood(estim_class, data):
-    estimator = estim_class()
     with pytest.raises(ValueError):
-        estimator.fit_transform(data, nbhd_type="wrong_unknown_type")
+        estimator = estim_class(nbhd_type="wrong_unknown_type")
+        #estimator.fit_transform(data)
 
 @pytest.mark.parametrize("estim_class", estimators)
 def test_fit_unknown_metric(estim_class, data):
-    estimator = estim_class()
+    estimator = estim_class(metric="wrong_unknown_metric")
     with pytest.raises(ValueError):
-        estimator.fit_transform(data, metric="wrong_unknown_metric")
+        estimator.fit_transform(data)
 
 @pytest.mark.parametrize("estim_class", estimators)
 def test_aggregation_unknown_comb(estim_class, data):
-    estimator = estim_class()
     with pytest.raises(ValueError):
-        estimator.fit_transform(data, comb="wrong_unknown_comb")
+        estimator = estim_class(comb="wrong_unknown_comb")
+        #estimator.fit_transform(data)
 
 @pytest.mark.parametrize("estim_class", estimators)
 def test_get_neigh_unknown_neighborhood(estim_class, data):
-    estimator = estim_class()
+    
     with pytest.raises(ValueError):
-        estimator.get_neigh(data, nbhd_type="wrong_unknown_type")
+        estimator = estim_class(nbhd_type="wrong_unknown_type")
+        #estimator.get_neigh(data)
 
 @pytest.mark.parametrize("estim_class", estimators)
 def test_get_neigh_unknown_metric(estim_class, data):
-    estimator = estim_class()
+    estimator = estim_class(metric="wrong_unknown_metric")
     with pytest.raises(ValueError):
-        estimator.get_neigh(data, metric="wrong_unknown_metric")
+        estimator.get_neigh(data)
 
 @pytest.mark.parametrize("estim_class", estimators)
 def test_aggregation_computes_global_dim(estim_class, data):
@@ -65,16 +66,16 @@ def test_fit_pw_computes_pw_dim(estim_class, data):
 def test_fit_single_job_equal_to_fit(estim_class, data):
     estimator_single = estim_class()
     estimator_single.fit(data)
-    estimator_multi = estim_class()
-    estimator_multi.fit(data, n_jobs=4)
+    estimator_multi = estim_class(n_jobs=4)
+    estimator_multi.fit(data)
     assert pytest.approx(estimator_single.dimension_) == pytest.approx(estimator_multi.dimension_)
 
 @pytest.mark.parametrize("estim_class", estimators)
 def test_fit_pw_single_job_equal_to_fit_pw(estim_class, data):
     estimator_single = estim_class()
     estimator_single.fit_pw(data)
-    estimator_multi = estim_class()
-    estimator_multi.fit_pw(data, n_jobs=4)
+    estimator_multi = estim_class(n_jobs=4)
+    estimator_multi.fit_pw(data)
     assert np.allclose(estimator_multi.dimension_pw_, estimator_single.dimension_pw_)
 
 @pytest.mark.parametrize("estim_class", estimators)

--- a/skdim/tests/flex/test_FlexNbhdEstimator.py
+++ b/skdim/tests/flex/test_FlexNbhdEstimator.py
@@ -16,32 +16,32 @@ def data():
 def test_fit_unknown_neighborhood(estim_class, data):
     with pytest.raises(ValueError):
         estimator = estim_class(nbhd_type="wrong_unknown_type")
-        #estimator.fit_transform(data)
+        estimator.fit_transform(data)
 
 @pytest.mark.parametrize("estim_class", estimators)
 def test_fit_unknown_metric(estim_class, data):
     with pytest.raises(ValueError):
         estimator = estim_class(metric="wrong_unknown_metric")
-        #estimator.fit_transform(data)
+        estimator.fit_transform(data)
 
 @pytest.mark.parametrize("estim_class", estimators)
 def test_aggregation_unknown_comb(estim_class, data):
     with pytest.raises(ValueError):
         estimator = estim_class(comb="wrong_unknown_comb")
-        #estimator.fit_transform(data)
+        estimator.fit_transform(data)
 
 @pytest.mark.parametrize("estim_class", estimators)
 def test_get_neigh_unknown_neighborhood(estim_class, data):
     
     with pytest.raises(ValueError):
         estimator = estim_class(nbhd_type="wrong_unknown_type")
-        #estimator.get_neigh(data)
+        estimator.get_neigh(data)
 
 @pytest.mark.parametrize("estim_class", estimators)
 def test_get_neigh_unknown_metric(estim_class, data):
     with pytest.raises(ValueError):
         estimator = estim_class(metric="wrong_unknown_metric")
-        #estimator.get_neigh(data)
+        estimator.get_neigh(data)
 
 @pytest.mark.parametrize("estim_class", estimators)
 def test_aggregation_computes_global_dim(estim_class, data):

--- a/skdim/tests/test_all_params.py
+++ b/skdim/tests/test_all_params.py
@@ -206,4 +206,4 @@ def test_fisher_separability_graph(monkeypatch):
     plt.title("PCA on original data")
     plt.xlabel("PC1")
     plt.ylabel("PC2")
-    plt.show()
+    #plt.show()


### PR DESCRIPTION
Modified flex neighbourhood estimator parent class to put static attributes/parameters in __init__ of objects in the class, rather than in fit. Added attribute type and value checks to both init and fit