### PR TITLE
Bayesian PCA (Laplace)

### DIFF
--- a/skdim/_commonfuncs.py
+++ b/skdim/_commonfuncs.py
@@ -397,7 +397,7 @@ class FlexNbhdEstimator(BaseEstimator):
         self.pt_nbhd_incl_pt = pt_nbhd_incl_pt 
         self.metric = metric
         self.comb = comb
-        self.smooth_flag = smooth
+        self.smooth = smooth
         self.n_jobs = n_jobs
         self.radius = radius
         self.n_neighbors = n_neighbors
@@ -416,7 +416,7 @@ class FlexNbhdEstimator(BaseEstimator):
                 raise ValueError(
                     "Estimator does not produce pointwise dimension estimate, no aggregation over pointwise dimension estimates is implemented."
                 )
-            if self.smooth_flag is not None:
+            if self.smooth is not None:
                 raise ValueError(
                     "Estimator does not produce pointwise dimension estimate, no smoothing over pointwise dimension estimates is implemented."
                 )
@@ -425,7 +425,7 @@ class FlexNbhdEstimator(BaseEstimator):
                 raise ValueError(
                     "Invalid comb parameter. It has to be 'mean' or 'median' or 'hmean'"
                 )
-            if not isinstance(self.smooth_flag, bool):
+            if not isinstance(self.smooth, bool):
                 raise TypeError(
                     "Invalid smooth parameter. It has to be bool"
                 )
@@ -534,7 +534,7 @@ class FlexNbhdEstimator(BaseEstimator):
         if self.pw_dim:
             self.is_fitted_pw_ = True
 
-            if self.smooth_flag:
+            if self.smooth:
                 self._smooth(nbhd_indices)
         else:
             self.is_fitted_ = True
@@ -708,7 +708,7 @@ class FlexNbhdEstimator(BaseEstimator):
             nbhd_indices=nbhd_indices,
         )
 
-        if self.smooth_flag:
+        if self.smooth:
             return self.dimension_pw_, self.dimension_pw_smooth_
         else:
             return self.dimension_pw_

--- a/skdim/id_flex/_PCA.py
+++ b/skdim/id_flex/_PCA.py
@@ -275,31 +275,31 @@ class lPCA(FlexNbhdEstimator):
         triu_idx = np.triu_indices(n = dmax, m = d, k =1)
 
         ### calculate the contributions of (lambda_i - lambda_j) terms, i = 1,...,k, j = i+1... d
-        Ediff = np.zeros([dmax,d])
-        Ediff[triu_idx] = np.log(np.maximum(eigenvalues[triu_idx[0]] - eigenvalues[triu_idx[1]], 1e-9))
-        Ediffterm = np.cumsum(np.sum(Ediff, axis = 1))
+        ediff = np.zeros([dmax,d])
+        ediff[triu_idx] = np.log(np.maximum(eigenvalues[triu_idx[0]] - eigenvalues[triu_idx[1]], 1e-9))
+        ediffterm = np.cumsum(np.sum(ediff, axis = 1))
 
         ### calculate the contributions of (1/hat lambda_j - 1/hat lambda_i) terms, i = 1,...,k, j = i+1... d
         ### First calculate i = 1,...,k, j = i+1... k, where hat lambda are equal to lambda
 
-        Ehatinvdiff = np.zeros([dmax, dmax])
+        ehatinvdiff = np.zeros([dmax, dmax])
         triu_idx = np.triu_indices(n = dmax, m = dmax, k =1)
-        Ehatinvdiff[triu_idx] = np.log(np.maximum(eigenvalues[triu_idx[0]] - eigenvalues[triu_idx[1]], 1e-9)) - np.log(np.maximum(eigenvalues[triu_idx[0]] * eigenvalues[triu_idx[1]], 1e-9))
-        Ehatinvdiffterm_a = np.cumsum(np.sum(Ehatinvdiff, axis = 0))
+        ehatinvdiff[triu_idx] = np.log(np.maximum(eigenvalues[triu_idx[0]] - eigenvalues[triu_idx[1]], 1e-9)) - np.log(np.maximum(eigenvalues[triu_idx[0]] * eigenvalues[triu_idx[1]], 1e-9))
+        ehatinvdiffterm_a = np.cumsum(np.sum(ehatinvdiff, axis = 0))
 
         ### second calculate i = 1,...,k, j = k...d, where hat lambda_i is lambda but hat lambda_j is nu 
 
         l = min(dmax, d - 1)
-        Ehatinvdiff_b = np.zeros([l,l])
+        ehatinvdiff_b = np.zeros([l,l])
         triu_idx = np.triu_indices(l, k =0)
-        Ehatinvdiff_b[triu_idx] = np.log(np.maximum(eigenvalues[triu_idx[0]] - nu[triu_idx[1]], 1e-9)) - np.log(np.maximum(eigenvalues[triu_idx[0]]*nu[triu_idx[1]], 1e-9))
+        ehatinvdiff_b[triu_idx] = np.log(np.maximum(eigenvalues[triu_idx[0]] - nu[triu_idx[1]], 1e-9)) - np.log(np.maximum(eigenvalues[triu_idx[0]]*nu[triu_idx[1]], 1e-9))
 
-        Ehatinvdiffterm_b = np.sum(Ehatinvdiff_b, axis = 0) * (d - np.arange(1, l + 1))
+        ehatinvdiffterm_b = np.sum(ehatinvdiff_b, axis = 0) * (d - np.arange(1, l + 1))
         
         ### calculate how this term varies with k
         s = np.zeros([dmax])
         s += m *np.log(N_pts)
-        s += Ediffterm
-        s += Ehatinvdiffterm_a
-        s[:l] += Ehatinvdiffterm_b
+        s += ediffterm
+        s += ehatinvdiffterm_a
+        s[:l] += ehatinvdiffterm_b
         return -s/2

--- a/skdim/tests/flex/pca_test.py
+++ b/skdim/tests/flex/pca_test.py
@@ -3,7 +3,7 @@ import numpy as np
 import skdim.id_flex
 from sklearn.datasets import make_swiss_roll
 
-VERSIONS = ["FO", "maxgap", "Kaiser", "broken_stick", "Laplace"]
+VERSIONS = ["FO", "maxgap", "Kaiser", "broken_stick", "LB"]
 
 
 @pytest.fixture

--- a/skdim/tests/flex/pca_test.py
+++ b/skdim/tests/flex/pca_test.py
@@ -3,7 +3,7 @@ import numpy as np
 import skdim.id_flex
 from sklearn.datasets import make_swiss_roll
 
-VERSIONS = ["FO", "maxgap", "Kaiser", "broken_stick"]
+VERSIONS = ["FO", "maxgap", "Kaiser", "broken_stick", "Laplace"]
 
 
 @pytest.fixture

--- a/skdim/tests/test_all_params.py
+++ b/skdim/tests/test_all_params.py
@@ -106,6 +106,7 @@ def test_lpca_params(data):
     x = skdim.id.lPCA(ver="Kaiser").fit(data)
     x = skdim.id.lPCA(ver="broken_stick").fit(data)
     x = skdim.id.lPCA(ver="participation_ratio").fit(data)
+    x = skdim.id.lPCA(ver="LB").fit(data)
 
 
 def test_tle_params(data):


### PR DESCRIPTION
Incorporated "Automatic Choice of Dimensionality for PCA" by Minka

Full paper here with corrections https://tminka.github.io/papers/pca/minka-pca.pdf
NeuRips version here https://proceedings.neurips.cc/paper_files/paper/2000/file/7503cfacd12053d309b6bed5c89de212-Paper.pdf

Uses Bayesian model selection to determine dimensionality.
Select ver = 'LB' in lPCA to toggle use.

Also changed lPCA so that verbose = True returns the eigenvalues or relevant data used to make cutoff in self.additional_data_