### PR TITLE
Remove repeated calculations in CDim

### DIFF
--- a/skdim/id_flex/_cdim.py
+++ b/skdim/id_flex/_cdim.py
@@ -83,11 +83,13 @@ class CDim(FlexNbhdEstimator):
                 for i in range(len(nbhd)):
                     if i in label:
                         continue
+                    new_label = label + [i]
+                    if new_label in new_label_set:
+                        continue
                     for vec_idx in label:
                         if T[i][vec_idx] >= 0:
                             break
                     else:
-                        new_label = label + [i]
                         new_label_set.append(new_label)
             label_set = new_label_set
         return de


### PR DESCRIPTION
The previous version was creating bigger label sets with the same labels appearing in different orders. It should be much more efficient now. @BinnieTropCFT - can you see if the experiments run in a reasonable time with this implementation?